### PR TITLE
WIP: Add our certificate file

### DIFF
--- a/recipe/conda_cert_path.diff
+++ b/recipe/conda_cert_path.diff
@@ -1,0 +1,14 @@
+diff --git libcloud/security.py libcloud/security.py
+index 4d024db..45fd235 100644
+--- libcloud/security.py
++++ libcloud/security.py
+@@ -39,6 +39,9 @@ SSL_VERSION = ssl.PROTOCOL_TLSv1
+ # File containing one or more PEM-encoded CA certificates
+ # concatenated together.
+ CA_CERTS_PATH = [
++    # conda cert path
++    '%PREFIX%/ssl/cacert.pem',
++
+     # centos/fedora: openssl
+     '/etc/pki/tls/certs/ca-bundle.crt',
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,10 +8,16 @@ source:
   fn: apache-libcloud-{{ version }}.tar.bz2
   url: http://apache.osuosl.org/libcloud/apache-libcloud-{{ version }}.tar.bz2
   sha1: fbf558d7e52336042dd9a456dec3a73f4b35e38e
+  patches:
+    # Ensure our certificates are first on the path.
+    - conda_cert_path.diff
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  script:
+    # Replace filer test with full prefix.
+    - python -c "import os; s = open('libcloud/security.py', 'r').read().replace('%PREFIX%', os.environ['PREFIX']); open('libcloud/security.py', 'w').write(s)"
+    - python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
@@ -23,6 +29,9 @@ requirements:
 test:
   imports:
     - libcloud
+
+  commands:
+    - python -c "from libcloud.security import CA_CERTS_PATH; print(CA_CERTS_PATH[0])"
 
 about:
   home: http://libcloud.apache.org


### PR DESCRIPTION
@danielfrg, I have added this PR as a way of addressing the [point raised](https://github.com/conda-forge/staged-recipes/pull/694#issuecomment-225750064) by @tonybaloney to make sure the certificate file is getting picked up. This looks like it works, but it may need a bit of clean up.

For instance, I used python to do a hacky `sed` like operation. I'm sure there is a better way to do this. Just this was really fast and I knew it would work on all platforms. Also, the test demonstrates it does the right thing, but doesn't currently verify it. Finally, using `has_prefix_files` would be desirable here, but I don't recall if this plays well with environment variables.

Please feel free to take this over and straighten this out.
