### PR TITLE
Add certifi as dependency and patch to use certifi CA bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-     
+      
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
       conda update --yes conda=4.0.8
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client conda=4.0.8
       conda config --add channels conda-forge
-      conda install conda=4.0.8
+      conda install --yes conda=4.0.8
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: objective-c
 
 env:
   matrix:
-
+    
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
@@ -33,7 +33,7 @@ install:
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-
+     
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: objective-c
 
 env:
   matrix:
-    
+
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
@@ -33,7 +33,8 @@ install:
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      
+      conda install conda=4.0.8
+
 
 script:
   - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,9 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda config --set show_channel_urls true
-      conda update --yes conda=4.0.8
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client conda=4.0.8
+      conda update --yes conda
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      conda install --yes conda=4.0.8
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ install:
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
       conda config --set show_channel_urls true
-      conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda update --yes conda=4.0.8
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client conda=4.0.8
       conda config --add channels conda-forge
       conda install conda=4.0.8
 

--- a/recipe/certifi.patch
+++ b/recipe/certifi.patch
@@ -1,0 +1,89 @@
+--- libcloud/security.py
++++ libcloud/security.py
+@@ -36,6 +36,10 @@ VERIFY_SSL_CERT = True
+
+ SSL_VERSION = ssl.PROTOCOL_TLSv1
+
++# True to use certifi CA bundle path when certifi library is available
++USE_CERTIFI = os.environ.get('LIBCLOUD_SSL_USE_CERTIFI', True)
++USE_CERTIFI = str(USE_CERTIFI).lower() in ['true', '1']
++
+ # File containing one or more PEM-encoded CA certificates
+ # concatenated together.
+ CA_CERTS_PATH = [
+@@ -74,6 +78,19 @@ if environment_cert_file is not None:
+     # don't want to fall-back to a potentially less restrictive bundle
+     CA_CERTS_PATH = [environment_cert_file]
+
++# Insert certifi CA bundle path to the front of Libcloud CA bundle search
++# path if certifi is available
++try:
++    import certifi
++except ImportError:
++    has_certifi = False
++else:
++    has_certifi = True
++
++if has_certifi and USE_CERTIFI:
++    certifi_ca_bundle_path = certifi.where()
++    CA_CERTS_PATH.insert(0, certifi_ca_bundle_path)
++
+ CA_CERTS_UNAVAILABLE_ERROR_MSG = (
+     'No CA Certificates were found in CA_CERTS_PATH. For information on '
+     'how to get required certificate files, please visit '
+--- libcloud/test/test_httplib_ssl.py
++++ libcloud/test/test_httplib_ssl.py
+@@ -105,6 +105,53 @@ class TestHttpLibSSLTests(unittest.TestCase):
+         self.assertRaisesRegexp(RuntimeError, expected_msg,
+                                 self.httplib_object._setup_ca_cert)
+
++    def test_certifi_ca_bundle_in_search_path(self):
++        mock_certifi_ca_bundle_path = '/certifi/bundle/path'
++
++        # Certifi not available
++        import libcloud.security
++        reload(libcloud.security)
++
++        original_length = len(libcloud.security.CA_CERTS_PATH)
++
++        self.assertTrue(mock_certifi_ca_bundle_path not in
++                        libcloud.security.CA_CERTS_PATH)
++
++        # Certifi is available
++        mock_certifi = mock.Mock()
++        mock_certifi.where.return_value = mock_certifi_ca_bundle_path
++        sys.modules['certifi'] = mock_certifi
++
++        # Certifi CA bundle path should be injected at the begining of search list
++        import libcloud.security
++        reload(libcloud.security)
++
++        self.assertEqual(libcloud.security.CA_CERTS_PATH[0],
++                         mock_certifi_ca_bundle_path)
++        self.assertEqual(len(libcloud.security.CA_CERTS_PATH),
++                         (original_length + 1))
++
++        # Certifi is available, but USE_CERTIFI is set to False
++        os.environ['LIBCLOUD_SSL_USE_CERTIFI'] = 'false'
++
++        import libcloud.security
++        reload(libcloud.security)
++
++        self.assertTrue(mock_certifi_ca_bundle_path not in
++                        libcloud.security.CA_CERTS_PATH)
++        self.assertEqual(len(libcloud.security.CA_CERTS_PATH), original_length)
++
++        # And enabled
++        os.environ['LIBCLOUD_SSL_USE_CERTIFI'] = 'true'
++
++        import libcloud.security
++        reload(libcloud.security)
++
++        self.assertEqual(libcloud.security.CA_CERTS_PATH[0],
++                         mock_certifi_ca_bundle_path)
++        self.assertEqual(len(libcloud.security.CA_CERTS_PATH),
++                         (original_length + 1))
++
+
+ if __name__ == '__main__':
+     sys.exit(unittest.main())

--- a/recipe/certifi_test.py
+++ b/recipe/certifi_test.py
@@ -1,0 +1,6 @@
+import sys
+from libcloud.security import CA_CERTS_PATH
+import certifi
+
+ok = 0 if certifi.where() in CA_CERTS_PATH else 1
+sys.exit(ok)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,9 @@ source:
   url: http://apache.osuosl.org/libcloud/apache-libcloud-{{ version }}.tar.bz2
   sha1: fbf558d7e52336042dd9a456dec3a73f4b35e38e
 
+  patches:
+    - certifi.patch
+
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
@@ -19,6 +22,7 @@ requirements:
     - setuptools
   run:
     - python
+    - certifi
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha1: fbf558d7e52336042dd9a456dec3a73f4b35e38e
 
   patches:
+    # Temporal patch to apply PR https://github.com/apache/libcloud/pull/812
     - certifi.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ test:
   imports:
     - libcloud
 
+  files:
+    - certifi_test.py
+
   commands:
     - python certifi_test.py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ test:
   imports:
     - libcloud
 
+  commands:
+    - python -c "import sys; from libcloud.security import CA_CERTS_PATH; import certifi; ok = 0 if certifi.where() in CA_CERTS_PATH else 1; sys.exit(ok)"
+
 about:
   home: http://libcloud.apache.org
   license: Apache License 2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
     - libcloud
 
   commands:
-    - python -c "import sys; from libcloud.security import CA_CERTS_PATH; import certifi; ok = 0 if certifi.where() in CA_CERTS_PATH else 1; sys.exit(ok)"
+    - python certifi_test.py
 
 about:
   home: http://libcloud.apache.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - certifi.patch
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Replaces https://github.com/conda-forge/apache-libcloud-feedstock/pull/1

Adds `certifi` as dependency and patches `libcloud` to use PR https://github.com/apache/libcloud/pull/812 from @Kami.

This is a temporal patch until that PR is integrated with libcloud.

cc. @jakirkham 
